### PR TITLE
Fix RISC-V Debian/Ubuntu dependencies install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  riscv64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/distro/debian
+++ b/distro/debian
@@ -187,9 +187,10 @@ distro_install_depends()
 	local script
 	local bm="$1"
 	local scripts=$(find $LKP_SRC/distro/depends/ -name "$bm" -o -name "${bm}.[0-9]")
+	local arch=$(get_system_arch)
 
 	export DEBIAN_FRONTEND=noninteractive
-	add_i386_package
+	[ "$arch" = "x86_64" ] && add_i386_package
 	update
 
 	apt-get install -yf

--- a/distro/depends/kernel-selftests
+++ b/distro/depends/kernel-selftests
@@ -4,20 +4,20 @@ gcc-multilib
 libc6-dev
 libc-bin
 libc6-dev-i386 (x86_64)
-libc6-dev-x32
+libc6-dev-x32 (x86_64)
 libc6
-lib32gcc-dev
-libx32gcc-dev
-libc6-i386
+lib32gcc-dev (x86_64)
+libx32gcc-dev (x86_64)
+libc6-i386 (x86_64)
 libc6-dev
-libc6-x32
-libx32gcc1
-libx32gomp1
-libx32itm1
-libx32atomic1
-libx32asan5
-libx32ubsan1
-libx32quadmath0
+libc6-x32 (x86_64)
+libx32gcc1 (x86_64)
+libx32gomp1 (x86_64)
+libx32itm1 (x86_64)
+libx32atomic1 (x86_64)
+libx32asan5 (x86_64)
+libx32ubsan1 (x86_64)
+libx32quadmath0 (x86_64)
 rsync
 make
 libcap-ng-dev

--- a/distro/depends/lkp-dev
+++ b/distro/depends/lkp-dev
@@ -17,9 +17,9 @@ cpio
 wget
 libklibc-dev
 linux-libc-dev
-#linux-libc-dev:i386
+linux-libc-dev:i386 (x86_64)
 libc6-dev
-#libc6-dev:i386
+libc6-dev:i386 (x86_64)
 ruby
 ruby-dev
 bzip2
@@ -29,4 +29,4 @@ flex
 bison
 libssl-dev
 libipc-run-perl
-#libc6-dev-x32
+libc6-dev-x32 (x86_64)

--- a/distro/installer/debian
+++ b/distro/installer/debian
@@ -1,8 +1,12 @@
 #!/bin/sh
 
+. $LKP_SRC/lib/detect-system.sh
+arch=$(get_system_arch)
+
 # Debian package installation
 export DEBIAN_FRONTEND=noninteractive
-dpkg --add-architecture i386 && apt-get update
+[ "$arch" = "x86_64" ] && dpkg --add-architecture i386
+apt-get update
 apt-get -o Dpkg::Options::="--force-confdef" \
      -o Dpkg::Options::="--force-confold" \
      -y install $* >/tmp/apt-get_info 2>&1

--- a/distro/installer/ubuntu
+++ b/distro/installer/ubuntu
@@ -1,8 +1,12 @@
 #!/bin/sh
 
-# enable i386 arch packages
-dpkg --add-architecture i386 && apt-get update
+. $LKP_SRC/lib/detect-system.sh
+arch=$(get_system_arch)
 
+# enable i386 arch packages
+[ "$arch" = "x86_64" ] && dpkg --add-architecture i386
+
+apt-get update
 apt-get -o Dpkg::Options::="--force-confdef" \
      -o Dpkg::Options::="--force-confold" \
      -o Dpkg::Options::="--force-overwrite" \


### PR DESCRIPTION
Not add i386 arch on Debian/Ubuntu RISC-V port, otherwise it will cause
apt update fails every time.

Mark amd64/i386 arch only packages so the existing package filtering code
can work, these packages do not exist on RISC-V port.

Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>

---

Previously some of the i386 arch repo packages were commented out and in this commit I've uncommented and marked with the arch info. We may clean up this part later for a formal PR to original lkp-tests.